### PR TITLE
ci(steward): switch pr-steward to @codex comment commands

### DIFF
--- a/.github/workflows/pr-steward.yml
+++ b/.github/workflows/pr-steward.yml
@@ -1,10 +1,12 @@
 name: codex pr steward
 
+# Comment-triggered only. The steward acts when a write-access collaborator
+# comments "@codex review", "@codex fix", or "@codex merge" on a PR. Nothing
+# fires automatically, and external users cannot invoke it (gated in the
+# reusable workflow on author_association).
 on:
-  pull_request:
-    types: [opened, reopened, ready_for_review, synchronize, edited, labeled, unlabeled]
-  pull_request_review:
-    types: [submitted, dismissed]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: write


### PR DESCRIPTION
## what

switches this repo's `pr-steward.yml` from `pull_request` / `pull_request_review` to `issue_comment: [created]`, matching the reworked reusable workflow (`StressTestor/StressTestor#1`).

the steward now runs only when a write-access collaborator comments `@codex review`, `@codex fix`, or `@codex merge`. nothing fires automatically, and external / fork PRs cannot trigger it.

## why

the old auto-trigger fired the privileged reusable job on fork PRs (and `pull_request_review` runs privileged even for forks). comment-triggered plus a push-permission gate in the reusable workflow means nothing runs unless a trusted human asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
